### PR TITLE
Add DelegateInfo rpc

### DIFF
--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -42,6 +42,7 @@ where
 	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
 	C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>,
 	C::Api: BlockBuilder<Block>,
+	C::Api: paratensor_custom_rpc_runtime_api::DelegateInfoRuntimeApi<Block>,
 	C::Api: paratensor_custom_rpc_runtime_api::NeuronInfoRuntimeApi<Block>,
 	C::Api: paratensor_custom_rpc_runtime_api::SubnetInfoRuntimeApi<Block>,
 	P: TransactionPool + Sync + Send + 'static,

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -42,6 +42,7 @@ where
 	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
 	C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>,
 	C::Api: BlockBuilder<Block>,
+	C::Api: paratensor_custom_rpc_runtime_api::NeuronInfoRuntimeApi<Block>,
 	C::Api: paratensor_custom_rpc_runtime_api::SubnetInfoRuntimeApi<Block>,
 	P: TransactionPool + Sync + Send + 'static,
 {

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -42,18 +42,18 @@ where
 	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
 	C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>,
 	C::Api: BlockBuilder<Block>,
-	C::Api: paratensor_custom_rpc_runtime_api::NeuronInfoRuntimeApi<Block>,
+	C::Api: paratensor_custom_rpc_runtime_api::SubnetInfoRuntimeApi<Block>,
 	P: TransactionPool + Sync + Send + 'static,
 {
 	use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApi};
 	use substrate_frame_rpc_system::{FullSystem, SystemApi};
-	use paratensor_custom_rpc::{NeuronInfoApi, NeuronInfo};
+	use paratensor_custom_rpc::{ParatensorCustomApi, ParatensorCustom};
 
 	let mut io = jsonrpc_core::IoHandler::default();
 	let FullDeps { client, pool, deny_unsafe } = deps;
 
-	// Custom RPC for getting neuron info
-	io.extend_with(NeuronInfoApi::to_delegate(NeuronInfo::new(client.clone())));
+	// Custom RPC methods for Paratensor
+	io.extend_with(ParatensorCustomApi::to_delegate(ParatensorCustom::new(client.clone())));
 
 	io.extend_with(SystemApi::to_delegate(FullSystem::new(client.clone(), pool, deny_unsafe)));
 	io.extend_with(TransactionPaymentApi::to_delegate(TransactionPayment::new(client)));

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -214,6 +214,7 @@ where
 		+ sp_block_builder::BlockBuilder<Block>
 		+ cumulus_primitives_core::CollectCollationInfo<Block>
 		+ pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>
+		+ paratensor_custom_rpc_runtime_api::DelegateInfoRuntimeApi<Block>
 		+ paratensor_custom_rpc_runtime_api::NeuronInfoRuntimeApi<Block>
 		+ paratensor_custom_rpc_runtime_api::SubnetInfoRuntimeApi<Block>
 		+ substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>,

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -215,6 +215,7 @@ where
 		+ cumulus_primitives_core::CollectCollationInfo<Block>
 		+ pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>
 		+ paratensor_custom_rpc_runtime_api::NeuronInfoRuntimeApi<Block>
+		+ paratensor_custom_rpc_runtime_api::SubnetInfoRuntimeApi<Block>
 		+ substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>,
 	sc_client_api::StateBackendFor<TFullBackend<Block>, Block>: sp_api::StateBackend<BlakeTwo256>,
 	Executor: sc_executor::NativeExecutionDispatch + 'static,

--- a/pallets/paratensor/rpc/src/lib.rs
+++ b/pallets/paratensor/rpc/src/lib.rs
@@ -12,19 +12,19 @@ pub use paratensor_custom_rpc_runtime_api::NeuronInfoRuntimeApi;
 use pallet_paratensor::neuron_info::NeuronInfo as NeuronInfoStruct;
 
 #[rpc]
-pub trait NeuronInfoApi<BlockHash> {
+pub trait ParatensorCustomApi<BlockHash> {
 	#[rpc(name = "neuronInfo_getNeurons")]
 	fn get_neurons(&self, netuid: u16, at: Option<BlockHash>) -> Result<Vec<NeuronInfoStruct>>;
 	#[rpc(name = "neuronInfo_getNeuron")]
 	fn get_neuron(&self, netuid: u16, uid: u16, at: Option<BlockHash>) -> Result<Option<NeuronInfoStruct>>;
 }
 
-pub struct NeuronInfo<C, M> {
+pub struct ParatensorCustom<C, M> {
 	client: Arc<C>,
 	_marker: std::marker::PhantomData<M>,
 }
 
-impl<C, M> NeuronInfo<C, M> {
+impl<C, M> ParatensorCustom<C, M> {
 	pub fn new(client: Arc<C>) -> Self {
 		Self {
 			client,
@@ -47,7 +47,7 @@ impl From<Error> for i64 {
 	}
 }
 
-impl<C, Block> NeuronInfoApi<<Block as BlockT>::Hash> for NeuronInfo<C, Block>
+impl<C, Block> ParatensorCustomApi<<Block as BlockT>::Hash> for ParatensorCustom<C, Block>
 where
 	Block: BlockT,
 	C: 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,

--- a/pallets/paratensor/rpc/src/lib.rs
+++ b/pallets/paratensor/rpc/src/lib.rs
@@ -11,12 +11,20 @@ use std::sync::Arc;
 pub use paratensor_custom_rpc_runtime_api::NeuronInfoRuntimeApi;
 use pallet_paratensor::neuron_info::NeuronInfo as NeuronInfoStruct;
 
+pub use paratensor_custom_rpc_runtime_api::SubnetInfoRuntimeApi;
+use pallet_paratensor::subnet_info::SubnetInfo as SubnetInfoStruct;
+
 #[rpc]
 pub trait ParatensorCustomApi<BlockHash> {
 	#[rpc(name = "neuronInfo_getNeurons")]
 	fn get_neurons(&self, netuid: u16, at: Option<BlockHash>) -> Result<Vec<NeuronInfoStruct>>;
 	#[rpc(name = "neuronInfo_getNeuron")]
 	fn get_neuron(&self, netuid: u16, uid: u16, at: Option<BlockHash>) -> Result<Option<NeuronInfoStruct>>;
+
+	#[rpc(name = "subnetInfo_getSubnetInfo")]
+	fn get_subnet_info(&self, netuid: u16, at: Option<BlockHash>) -> Result<Option<SubnetInfoStruct>>;
+	#[rpc(name = "subnetInfo_getSubnetsInfo")]
+	fn get_subnets_info(&self, at: Option<BlockHash>) -> Result<Vec<Option<SubnetInfoStruct>>>;
 }
 
 pub struct ParatensorCustom<C, M> {
@@ -52,6 +60,7 @@ where
 	Block: BlockT,
 	C: 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,
 	C::Api: NeuronInfoRuntimeApi<Block>,
+	C::Api: SubnetInfoRuntimeApi<Block>,
 	{ 
 	fn get_neurons(&self, netuid: u16, at: Option<<Block as BlockT>::Hash>) -> Result<Vec<NeuronInfoStruct>> {
 		let api = self.client.runtime_api();
@@ -75,6 +84,32 @@ where
 		api.get_neuron(&at, netuid, uid).map_err(|e| RpcError {
 			code: ErrorCode::ServerError(Error::RuntimeError.into()),
 			message: "Unable to get neuron info.".into(),
+			data: Some(e.to_string().into()),
+		})
+	}
+	
+	fn get_subnet_info(&self, netuid: u16, at: Option<<Block as BlockT>::Hash>) -> Result<Option<SubnetInfoStruct>> {
+		let api = self.client.runtime_api();
+		let at = BlockId::hash(at.unwrap_or_else(||
+			// If the block hash is not supplied assume the best block.
+			self.client.info().best_hash));
+
+		api.get_subnet_info(&at, netuid).map_err(|e| RpcError {
+			code: ErrorCode::ServerError(Error::RuntimeError.into()),
+			message: "Unable to get subnet info.".into(),
+			data: Some(e.to_string().into()),
+		})
+	}
+
+	fn get_subnets_info(&self, at: Option<<Block as BlockT>::Hash>) -> Result<Vec<Option<SubnetInfoStruct>>> {
+		let api = self.client.runtime_api();
+		let at = BlockId::hash(at.unwrap_or_else(||
+			// If the block hash is not supplied assume the best block.
+			self.client.info().best_hash));
+
+		api.get_subnets_info(&at).map_err(|e| RpcError {
+			code: ErrorCode::ServerError(Error::RuntimeError.into()),
+			message: "Unable to get subnets info.".into(),
 			data: Some(e.to_string().into()),
 		})
 	}

--- a/pallets/paratensor/runtime-api/src/lib.rs
+++ b/pallets/paratensor/runtime-api/src/lib.rs
@@ -1,13 +1,19 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 use pallet_paratensor::neuron_info::NeuronInfo as NeuronInfoStruct;
+use pallet_paratensor::subnet_info::SubnetInfo as SubnetInfoStruct;
 extern crate alloc;
 use alloc::vec::Vec;
 
 // Here we declare the runtime API. It is implemented it the `impl` block in
-// src/neuron_info.rs
+// src/neuron_info.rs and src/subnet_info.rs
 sp_api::decl_runtime_apis! {
 	pub trait NeuronInfoRuntimeApi {
 		fn get_neurons(netuid: u16) -> Vec<NeuronInfoStruct>;
 		fn get_neuron(netuid: u16, uid: u16) -> Option<NeuronInfoStruct>;
+	}
+
+	pub trait SubnetInfoRuntimeApi {
+		fn get_subnet_info(netuid: u16) -> Option<SubnetInfoStruct>;
+		fn get_subnets_info() -> Vec<Option<SubnetInfoStruct>>;
 	}
 }

--- a/pallets/paratensor/runtime-api/src/lib.rs
+++ b/pallets/paratensor/runtime-api/src/lib.rs
@@ -1,11 +1,12 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 use pallet_paratensor::neuron_info::NeuronInfo as NeuronInfoStruct;
 use pallet_paratensor::subnet_info::SubnetInfo as SubnetInfoStruct;
+use pallet_paratensor::delegate_info::DelegateInfo as DelegateInfoStruct;
 extern crate alloc;
 use alloc::vec::Vec;
 
 // Here we declare the runtime API. It is implemented it the `impl` block in
-// src/neuron_info.rs and src/subnet_info.rs
+// src/neuron_info.rsm src/subnet_info.rs, and src/delegate_info.rs
 sp_api::decl_runtime_apis! {
 	pub trait NeuronInfoRuntimeApi {
 		fn get_neurons(netuid: u16) -> Vec<NeuronInfoStruct>;
@@ -15,5 +16,10 @@ sp_api::decl_runtime_apis! {
 	pub trait SubnetInfoRuntimeApi {
 		fn get_subnet_info(netuid: u16) -> Option<SubnetInfoStruct>;
 		fn get_subnets_info() -> Vec<Option<SubnetInfoStruct>>;
+	}
+
+	pub trait DelegateInfoRuntimeApi {
+		fn get_delegates() -> Vec<DelegateInfoStruct>;
+		fn get_delegate( delegate_account_vec: Vec<u8> ) -> Option<DelegateInfoStruct>;
 	}
 }

--- a/pallets/paratensor/runtime-api/src/lib.rs
+++ b/pallets/paratensor/runtime-api/src/lib.rs
@@ -1,13 +1,18 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+use pallet_paratensor::delegate_info::DelegateInfo as DelegateInfoStruct;
 use pallet_paratensor::neuron_info::NeuronInfo as NeuronInfoStruct;
 use pallet_paratensor::subnet_info::SubnetInfo as SubnetInfoStruct;
-use pallet_paratensor::delegate_info::DelegateInfo as DelegateInfoStruct;
 extern crate alloc;
 use alloc::vec::Vec;
 
 // Here we declare the runtime API. It is implemented it the `impl` block in
 // src/neuron_info.rsm src/subnet_info.rs, and src/delegate_info.rs
 sp_api::decl_runtime_apis! {
+	pub trait DelegateInfoRuntimeApi {
+		fn get_delegates() -> Vec<DelegateInfoStruct>;
+		fn get_delegate( delegate_account_vec: Vec<u8> ) -> Option<DelegateInfoStruct>;
+	}
+
 	pub trait NeuronInfoRuntimeApi {
 		fn get_neurons(netuid: u16) -> Vec<NeuronInfoStruct>;
 		fn get_neuron(netuid: u16, uid: u16) -> Option<NeuronInfoStruct>;
@@ -16,10 +21,5 @@ sp_api::decl_runtime_apis! {
 	pub trait SubnetInfoRuntimeApi {
 		fn get_subnet_info(netuid: u16) -> Option<SubnetInfoStruct>;
 		fn get_subnets_info() -> Vec<Option<SubnetInfoStruct>>;
-	}
-
-	pub trait DelegateInfoRuntimeApi {
-		fn get_delegates() -> Vec<DelegateInfoStruct>;
-		fn get_delegate( delegate_account_vec: Vec<u8> ) -> Option<DelegateInfoStruct>;
 	}
 }

--- a/pallets/paratensor/src/delegate_info.rs
+++ b/pallets/paratensor/src/delegate_info.rs
@@ -1,0 +1,65 @@
+use super::*;
+use frame_support::IterableStorageDoubleMap;
+use serde::{Serialize, Deserialize};
+use frame_support::storage::IterableStorageMap;
+use frame_support::pallet_prelude::{Decode, Encode};
+extern crate alloc;
+use alloc::vec::Vec;
+use sp_core::hexdisplay::AsBytesRef;
+
+
+#[derive(Decode, Encode, Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct DelegateInfo {
+    delegate_ss58: DeAccountId,
+    take: u16,
+    nominators: Vec<(DeAccountId, u64)>, // map of nominator_ss58 to stake amount
+    owner_ss58: DeAccountId
+}
+
+impl<T: Config> Pallet<T> {
+	pub fn get_delegate( delegate_account_vec: Vec<u8> ) -> Option<DelegateInfo> {
+        if delegate_account_vec.len() != 32 {
+            return None;
+        }
+
+        let delegate: AccountIdOf<T> = T::AccountId::decode( &mut delegate_account_vec.as_bytes_ref() ).unwrap();
+
+        let mut nominators = Vec::<(DeAccountId, u64)>::new();
+
+        for ( nominator, stake ) in < Stake<T> as IterableStorageDoubleMap<T::AccountId, T::AccountId, u64> >::iter_prefix( delegate.clone() ) {
+            nominators.push( ( nominator.clone().encode().into(), stake ) );
+        }
+
+        let owner = <Owner<T>>::get( delegate.clone() );
+
+        return Some( DelegateInfo {
+            delegate_ss58: delegate.clone().encode().into(),
+            take: <Delegates<T>>::get( delegate.clone() ),
+            nominators,
+            owner_ss58: owner.clone().encode().into()
+        });
+	}
+
+    pub fn get_delegates() -> Vec<DelegateInfo> {
+        let mut delegates = Vec::<DelegateInfo>::new();
+        for ( delegate, take ) in < Delegates<T> as IterableStorageMap<T::AccountId, u16> >::iter() {
+            let mut nominators = Vec::<(DeAccountId, u64)>::new();
+            for ( nominator, stake ) in < Stake<T> as IterableStorageDoubleMap<T::AccountId, T::AccountId, u64> >::iter_prefix( delegate.clone() ) {
+                nominators.push( ( nominator.clone().encode().into(), stake ) );
+            }
+
+            let owner = <Owner<T>>::get( delegate.clone() );
+
+            delegates.push( DelegateInfo {
+                delegate_ss58: delegate.clone().encode().into(),
+                take,
+                nominators,
+                owner_ss58: owner.clone().encode().into()
+            });
+        }
+
+        return delegates;
+	}
+}
+

--- a/pallets/paratensor/src/lib.rs
+++ b/pallets/paratensor/src/lib.rs
@@ -124,6 +124,20 @@ pub mod pallet {
 
 	pub type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
 
+	#[derive(Decode, Encode, Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
+	pub struct DeAccountId { // allows us to de/serialize the account id as a u8 vec
+		#[serde(with = "serde_bytes")]
+		id: Vec<u8>
+	}
+
+	impl From<Vec<u8>> for DeAccountId {
+		fn from(v: Vec<u8>) -> Self {
+			DeAccountId {
+				id: v.clone()
+			}
+		}
+	}
+
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]
 	#[pallet::without_storage_info]
@@ -283,20 +297,6 @@ pub mod pallet {
         pub ip_type: u8, // --- Prometheus ip type, 4 for ipv4 and 6 for ipv6.
 	}
 
-
-	#[derive(Decode, Encode, Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
-	pub struct DeAccountId { // allows us to de/serialize the account id as a u8 vec
-		#[serde(with = "serde_bytes")]
-		id: Vec<u8>
-	}
-
-	impl From<Vec<u8>> for DeAccountId {
-		fn from(v: Vec<u8>) -> Self {
-			DeAccountId {
-				id: v.clone()
-			}
-		}
-	}
 
 	#[pallet::type_value] 
 	pub fn DefaultServingRateLimit<T: Config>() -> u64 { T::InitialServingRateLimit::get() }

--- a/pallets/paratensor/src/lib.rs
+++ b/pallets/paratensor/src/lib.rs
@@ -28,6 +28,8 @@ mod weights;
 mod networks;
 mod serving; 
 mod block_step;
+// RPC impl imports
+pub mod delegate_info;
 pub mod neuron_info;
 pub mod subnet_info;
 

--- a/pallets/paratensor/src/lib.rs
+++ b/pallets/paratensor/src/lib.rs
@@ -29,6 +29,7 @@ mod networks;
 mod serving; 
 mod block_step;
 pub mod neuron_info;
+pub mod subnet_info;
 
 #[frame_support::pallet]
 pub mod pallet {

--- a/pallets/paratensor/src/lib.rs
+++ b/pallets/paratensor/src/lib.rs
@@ -281,6 +281,21 @@ pub mod pallet {
         pub ip_type: u8, // --- Prometheus ip type, 4 for ipv4 and 6 for ipv6.
 	}
 
+
+	#[derive(Decode, Encode, Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
+	pub struct DeAccountId { // allows us to de/serialize the account id as a u8 vec
+		#[serde(with = "serde_bytes")]
+		id: Vec<u8>
+	}
+
+	impl From<Vec<u8>> for DeAccountId {
+		fn from(v: Vec<u8>) -> Self {
+			DeAccountId {
+				id: v.clone()
+			}
+		}
+	}
+
 	#[pallet::type_value] 
 	pub fn DefaultServingRateLimit<T: Config>() -> u64 { T::InitialServingRateLimit::get() }
 

--- a/pallets/paratensor/src/neuron_info.rs
+++ b/pallets/paratensor/src/neuron_info.rs
@@ -29,21 +29,6 @@ pub struct NeuronInfo {
     pruning_score: u16
 }
 
-#[derive(Decode, Encode, Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
-struct DeAccountId { // allows us to de/serialize the account id as a u8 vec
-    #[serde(with = "serde_bytes")]
-    id: Vec<u8>
-}
-
-impl From<Vec<u8>> for DeAccountId {
-    fn from(v: Vec<u8>) -> Self {
-        DeAccountId {
-            id: v.clone()
-        }
-    }
-}
-
-
 impl<T: Config> Pallet<T> {
 	pub fn get_neurons(netuid: u16) -> Vec<NeuronInfo> {
         if !Self::if_subnet_exist(netuid) {

--- a/pallets/paratensor/src/subnet_info.rs
+++ b/pallets/paratensor/src/subnet_info.rs
@@ -1,0 +1,117 @@
+ use super::*;
+use frame_support::IterableStorageDoubleMap;
+use serde::{Serialize, Deserialize};
+use frame_support::storage::IterableStorageMap;
+use frame_support::pallet_prelude::{Decode, Encode};
+extern crate alloc;
+use alloc::vec::Vec;
+
+#[derive(Decode, Encode, Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct SubnetInfo {
+    netuid: u16,
+    rho: u16,
+    kappa: u16,
+    difficulty: u64,
+    immunity_period: u16,
+    validator_batch_size: u16,
+    validator_sequence_length: u16,
+    validator_epochs_per_reset: u16,
+    validator_epoch_length: u16,
+    max_allowed_validators: u16,
+    min_allowed_weights: u16,
+    max_weights_limit: u16,
+    scaling_law_power: u16,
+    synergy_scaling_law_power: u16,
+    subnetwork_n: u16,
+    max_allowed_uids: u16,
+    blocks_since_last_step: u64,
+    tempo: u16,
+    network_modality: u16,
+    network_connect: Vec<u16>,
+    emission_values: u64
+}
+
+impl<T: Config> Pallet<T> {
+	pub fn get_subnet_info(netuid: u16) -> Option<SubnetInfo> {
+        if !Self::if_subnet_exist(netuid) {
+            return None;
+        }
+
+        let rho = <Rho<T>>::get(netuid);
+        let kappa = <Kappa<T>>::get(netuid);
+        let difficulty = <Difficulty<T>>::get(netuid);
+        let immunity_period = <ImmunityPeriod<T>>::get(netuid);
+        let validator_batch_size = <ValidatorBatchSize<T>>::get(netuid);
+        let validator_sequence_length = <ValidatorSequenceLength<T>>::get(netuid);
+        let validator_epochs_per_reset = <ValidatorEpochsPerReset<T>>::get(netuid);
+        let validator_epoch_length = <ValidatorEpochLen<T>>::get(netuid);
+        let max_allowed_validators = <MaxAllowedValidators<T>>::get(netuid);
+        let min_allowed_weights = <MinAllowedWeights<T>>::get(netuid);
+        let max_weights_limit = <MaxWeightsLimit<T>>::get(netuid);
+        let scaling_law_power = <ScalingLawPower<T>>::get(netuid);
+        let synergy_scaling_law_power = <SynergyScalingLawPower<T>>::get(netuid);
+        let subnetwork_n = <SubnetworkN<T>>::get(netuid);
+        let max_allowed_uids = <MaxAllowedUids <T>>::get(netuid);
+        let blocks_since_last_step = <BlocksSinceLastStep <T>>::get(netuid);
+        let tempo = <Tempo <T>>::get(netuid);
+        let network_modality = <NetworkModality <T>>::get(netuid);
+        let emission_values = <EmissionValues <T>>::get(netuid);
+
+
+        let mut network_connect: Vec<u16> = Vec::<u16>::new();
+
+        for ( _netuid_, con_req) in < NetworkConnect<T> as IterableStorageDoubleMap<u16, u16, u16> >::iter_prefix(netuid) {
+            network_connect.push(con_req);
+        }
+
+        return Some(SubnetInfo {
+            rho,
+            kappa,
+            difficulty,
+            immunity_period,
+            netuid,
+            validator_batch_size,
+            validator_sequence_length,
+            validator_epochs_per_reset,
+            validator_epoch_length,
+            max_allowed_validators,
+            min_allowed_weights,
+            max_weights_limit,
+            scaling_law_power,
+            synergy_scaling_law_power,
+            subnetwork_n,
+            max_allowed_uids,
+            blocks_since_last_step,
+            tempo,
+            network_modality,
+            network_connect,
+            emission_values
+        })
+	}
+
+    pub fn get_subnets_info() -> Vec<Option<SubnetInfo>> {
+        let mut subnet_netuids = Vec::<u16>::new();
+        let mut max_netuid: u16 = 0;
+        for ( netuid, added ) in < NetworksAdded<T> as IterableStorageMap<u16, bool> >::iter() {
+            if added {
+                subnet_netuids.push(netuid);
+                if netuid > max_netuid {
+                    max_netuid = netuid;
+                }
+            }
+        }
+
+        let mut subnets_info = Vec::<Option<SubnetInfo>>::new();
+        for netuid_ in 0..max_netuid {
+            if subnet_netuids.contains(&netuid_) {
+                subnets_info.push(Self::get_subnet_info(netuid_));
+            } else {
+                subnets_info.push(None);
+            }
+        }
+
+        return subnets_info;
+	}
+}
+

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -752,6 +752,16 @@ impl_runtime_apis! {
 		}
 	}
 
+	impl paratensor_custom_rpc_runtime_api::DelegateInfoRuntimeApi<Block> for Runtime {
+		fn get_delegates() -> Vec<pallet_paratensor::delegate_info::DelegateInfo> {
+			Paratensor::get_delegates()
+		}
+
+		fn get_delegate(delegate_account_vec: Vec<u8>) -> Option<pallet_paratensor::delegate_info::DelegateInfo> {
+			Paratensor::get_delegate(delegate_account_vec)
+		}
+	}
+
 	impl paratensor_custom_rpc_runtime_api::NeuronInfoRuntimeApi<Block> for Runtime {
 		fn get_neurons(netuid: u16) -> Vec<pallet_paratensor::neuron_info::NeuronInfo> {
 			Paratensor::get_neurons(netuid)

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -761,6 +761,16 @@ impl_runtime_apis! {
 			Paratensor::get_neuron(netuid, uid)
 		}
 	}
+
+	impl paratensor_custom_rpc_runtime_api::SubnetInfoRuntimeApi<Block> for Runtime {
+		fn get_subnet_info(netuid: u16) -> Option<pallet_paratensor::subnet_info::SubnetInfo> {
+			Paratensor::get_subnet_info(netuid)
+		}
+
+		fn get_subnets_info() -> Vec<Option<pallet_paratensor::subnet_info::SubnetInfo>> {
+			Paratensor::get_subnets_info()
+		}
+	}
 }
 
 struct CheckInherents;


### PR DESCRIPTION
This PR adds the rpc methods: `delegateInfo_getDelegate (hotkey_acct_id_as_u8_array)` and `delegateInfo_getDelegates`  

This allows us to quickly pull the delegateInfo from the chain, including all nominators of the delegate and the amounts they staked.

Tested locally using current testnet state.