### PR TITLE
Limit uids by subnet max

### DIFF
--- a/pallets/paratensor/Cargo.toml
+++ b/pallets/paratensor/Cargo.toml
@@ -37,7 +37,7 @@ serde_bytes = { version = "0.11.8", default-features = false, features = ["alloc
 serde_with = { version = "=2.0.0", default-features = false, features=["macros"] }
 
 [dev-dependencies]
-pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.20" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.20", features = ["std"] }
 sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.20" }
 # Substrate
 sp-tracing = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.20" }

--- a/pallets/paratensor/src/lib.rs
+++ b/pallets/paratensor/src/lib.rs
@@ -527,6 +527,7 @@ pub mod pallet {
 		NoValidatorPermit, // ---- Thrown when the caller attempts to set non-self weights without being a permitted validator.
 		WeightVecNotEqualSize, // ---- Thrown when the caller attempts to set the weight keys and values but these vectors have different size.
 		DuplicateUids, // ---- Thrown when the caller attempts to set weights with duplicate uids in the weight matrix.
+		TooManyUids, // ---- Thrown when the caller attempts to set weights with more uids than allowed.
 		InvalidUid, // ---- Thrown when a caller attempts to set weight to at least one uid that does not exist in the metagraph.
 		NotSettingEnoughWeights, // ---- Thrown when the dispatch attempts to set weights on chain with fewer elements than are allowed.
 		TooManyRegistrationsThisBlock, // ---- Thrown when registrations this block exceeds allowed number.
@@ -620,6 +621,9 @@ pub mod pallet {
 		///
 		/// 	* 'DuplicateUids':
 		/// 		- Attempting to set weights with duplicate uids.
+		///		
+		///     * 'TooManyUids':
+		/// 		- Attempting to set weights above the max allowed uids.
 		///
 		/// 	* 'InvalidUid':
 		/// 		- Attempting to set weights with invalid uids.

--- a/pallets/paratensor/src/weights.rs
+++ b/pallets/paratensor/src/weights.rs
@@ -74,7 +74,7 @@ impl<T: Config> Pallet<T> {
         ensure!( Self::if_subnet_exist( netuid ), Error::<T>::NetworkDoesNotExist );
         
         // --- 4. Check to see if the number of uids is within the max allowed uids for this network.
-        ensure!( Self::check_len_uids_within_max( netuid, &uids ), Error::<T>::TooManyUids);
+        ensure!( Self::check_len_uids_within_allowed( netuid, &uids ), Error::<T>::TooManyUids);
 
         // --- 5. Check to see if the hotkey is registered to the passed network.
         ensure!( Self::is_hotkey_registered_on_network( netuid, &hotkey ), Error::<T>::NotRegistered );
@@ -235,10 +235,11 @@ impl<T: Config> Pallet<T> {
         return true;
     }
 
-    /// Returns False is the number of uids exceeds the max_allowed_uids for this network.
-    pub fn check_len_uids_within_max( netuid: u16, uids: &Vec<u16> ) -> bool {
-        let max_allowed_uids: u16 = Self::get_max_allowed_uids( netuid );
-        return uids.len() <= max_allowed_uids as usize;
+    /// Returns False is the number of uids exceeds the allowed number of uids for this network.
+    pub fn check_len_uids_within_allowed( netuid: u16, uids: &Vec<u16> ) -> bool {
+        let subnetwork_n: u16 = Self::get_subnetwork_n( netuid );
+        // we should expect at most subnetwork_n uids.
+        return uids.len() <= subnetwork_n as usize;
     }
     
 }

--- a/pallets/paratensor/src/weights.rs
+++ b/pallets/paratensor/src/weights.rs
@@ -64,59 +64,59 @@ impl<T: Config> Pallet<T> {
         let hotkey = ensure_signed( origin )?;
         log::info!("do_set_weights( origin:{:?} netuid:{:?}, uids:{:?}, values:{:?})", hotkey, netuid, uids, values );
 
-        // --- 2. Check to see if this is a valid network.
-        ensure!( Self::if_subnet_exist( netuid ), Error::<T>::NetworkDoesNotExist );
+        // --- 2. Check that the length of uid list and value list are equal for this network.
+        ensure!( Self::uids_match_values( &uids, &values ), Error::<T>::WeightVecNotEqualSize );
 
-        // --- 3. Check to see if the hotkey is registered to the passed network.
+        // --- 3. Check to see if this is a valid network.
+        ensure!( Self::if_subnet_exist( netuid ), Error::<T>::NetworkDoesNotExist );
+        
+        // --- 5. Check to see if the hotkey is registered to the passed network.
         ensure!( Self::is_hotkey_registered_on_network( netuid, &hotkey ), Error::<T>::NotRegistered );
 
-        // --- 4. Ensure version_key is up-to-date.
+        // --- 6. Ensure version_key is up-to-date.
         ensure!( Self::check_version_key( netuid, version_key ), Error::<T>::IncorrectNetworkVersionKey );
 
-        // --- 5. Get the neuron uid of associated hotkey on network netuid.
+        // --- 7. Get the neuron uid of associated hotkey on network netuid.
         let neuron_uid;
         match Self::get_uid_for_net_and_hotkey( netuid, &hotkey ) { Ok(k) => neuron_uid = k, Err(e) => panic!("Error: {:?}", e) } 
 
-        // --- 6. Ensure the uid is not setting weights faster than the weights_set_rate_limit.
+        // --- 8. Ensure the uid is not setting weights faster than the weights_set_rate_limit.
         let current_block: u64 = Self::get_current_block_as_u64();
         ensure!( Self::check_rate_limit( netuid, neuron_uid, current_block ), Error::<T>::SettingWeightsTooFast );
 
-        // --- 7. Check that the neuron uid is an allowed validator permitted to set non-self weights.
+        // --- 9. Check that the neuron uid is an allowed validator permitted to set non-self weights.
         ensure!( Self::check_validator_permit( netuid, neuron_uid, &uids, &values ), Error::<T>::NoValidatorPermit );
 
-        // --- 8. Check that the length of uid list and value list are equal for this network.
-        ensure!( Self::uids_match_values( &uids, &values ), Error::<T>::WeightVecNotEqualSize );
-
-        // --- 9. Ensure the passed uids contain no duplicates.
+        // --- 10. Ensure the passed uids contain no duplicates.
         ensure!( !Self::has_duplicate_uids( &uids ), Error::<T>::DuplicateUids );
 
-        // --- 10. Ensure that the passed uids are valid for the network.
+        // --- 11. Ensure that the passed uids are valid for the network.
         ensure!( !Self::contains_invalid_uids( netuid, &uids ), Error::<T>::InvalidUid );
 
-        // --- 11. Ensure that the weights have the required length.
+        // --- 12. Ensure that the weights have the required length.
         ensure!( Self::check_length( netuid, neuron_uid, &uids, &values ), Error::<T>::NotSettingEnoughWeights );
 
-        // --- 12. Normalize the weights.
+        // --- 13. Normalize the weights.
         let normalized_values = Self::normalize_weights( values );
 
-        // --- 13. Ensure the weights are max weight limited 
+        // --- 14. Ensure the weights are max weight limited 
         ensure!( Self::max_weight_limited( netuid, neuron_uid, &uids, &normalized_values ), Error::<T>::MaxWeightExceeded );
 
-        // --- 14. Zip weights for sinking to storage map.
+        // --- 15. Zip weights for sinking to storage map.
         let mut zipped_weights: Vec<( u16, u16 )> = vec![];
         for ( uid, val ) in uids.iter().zip(normalized_values.iter()) { zipped_weights.push((*uid, *val)) }
 
-        // --- 15. Set weights under netuid, uid double map entry.
+        // --- 16. Set weights under netuid, uid double map entry.
         Weights::<T>::insert( netuid, neuron_uid, zipped_weights );
 
-        // --- 16. Set the activity for the weights on this network.
+        // --- 17. Set the activity for the weights on this network.
         LastUpdate::<T>::insert( netuid, neuron_uid, current_block );
 
-        // --- 17; Emit the tracking event.
+        // --- 18. Emit the tracking event.
         log::info!("WeightsSet( netuid:{:?}, neuron_uid:{:?} )", netuid, neuron_uid );
         Self::deposit_event( Event::WeightsSet( netuid, neuron_uid ) );
 
-        // --- 18. Return ok.
+        // --- 19. Return ok.
         Ok(())
     }
 

--- a/pallets/paratensor/src/weights.rs
+++ b/pallets/paratensor/src/weights.rs
@@ -48,6 +48,9 @@ impl<T: Config> Pallet<T> {
     ///
     /// 	* 'DuplicateUids':
     /// 		- Attempting to set weights with duplicate uids.
+    /// 
+    ///     * 'TooManyUids':
+    /// 		- Attempting to set weights above the max allowed uids.
     ///
     /// 	* 'InvalidUid':
     /// 		- Attempting to set weights with invalid uids.
@@ -70,6 +73,9 @@ impl<T: Config> Pallet<T> {
         // --- 3. Check to see if this is a valid network.
         ensure!( Self::if_subnet_exist( netuid ), Error::<T>::NetworkDoesNotExist );
         
+        // --- 4. Check to see if the number of uids is within the max allowed uids for this network.
+        ensure!( Self::check_len_uids_within_max( netuid, &uids ), Error::<T>::TooManyUids);
+
         // --- 5. Check to see if the hotkey is registered to the passed network.
         ensure!( Self::is_hotkey_registered_on_network( netuid, &hotkey ), Error::<T>::NotRegistered );
 
@@ -227,6 +233,12 @@ impl<T: Config> Pallet<T> {
         if weights.len() != 1 { return false; }
         if uid != uids[0] { return false; } 
         return true;
+    }
+
+    /// Returns False is the number of uids exceeds the max_allowed_uids for this network.
+    pub fn check_len_uids_within_max( netuid: u16, uids: &Vec<u16> ) -> bool {
+        let max_allowed_uids: u16 = Self::get_max_allowed_uids( netuid );
+        return uids.len() <= max_allowed_uids as usize;
     }
     
 }

--- a/pallets/paratensor/tests/weights.rs
+++ b/pallets/paratensor/tests/weights.rs
@@ -234,13 +234,21 @@ fn test_no_signature() {
 	});
 }
 
-/// Tests that weights cannot be set to non registered uids.
+/// Tests that weights cannot be set BY non-registered hotkeys.
 #[test]
 fn test_set_weights_err_not_active() {
 	new_test_ext().execute_with(|| {
-		let weights_keys: Vec<u16> = vec![1, 2, 3, 4, 5, 6];
-		let weight_values: Vec<u16> = vec![1, 2, 3, 4, 5, 6];
-		add_network(1, 13, 0);
+		let netuid: u16 = 1;
+		let tempo: u16 = 13;
+		add_network(netuid, tempo, 0);
+
+		// Register one neuron. Should have uid 0
+		register_ok_neuron(1, 666, 2, 100000);
+		ParatensorModule::get_uid_for_net_and_hotkey( netuid, &666 ).expect("Not registered.");
+
+		let weights_keys: Vec<u16> = vec![0]; // Uid 0 is valid.
+		let weight_values: Vec<u16> = vec![1];
+		// This hotkey is NOT registered.
 		let result = ParatensorModule::set_weights(Origin::signed(1), 1, weights_keys, weight_values, 0);
 		assert_eq!(result, Err(Error::<Test>::NotRegistered.into()));
 	});


### PR DESCRIPTION
This PR adds some extra checks to the set weights call to limit check time for invalid extrinsics.  

This PR also updates any set weights tests due to this change.   

This PR also adds the `std` feature to `pallet-balances` as it was throwing during compilation