### PR TITLE
New val hyper params

### DIFF
--- a/pallets/paratensor/src/lib.rs
+++ b/pallets/paratensor/src/lib.rs
@@ -350,21 +350,21 @@ pub mod pallet {
 	#[pallet::type_value]
 	pub fn DefaultBondsMovingAverage<T: Config>() -> u64 { T::InitialBondsMovingAverage::get() }
 	#[pallet::type_value] 
+	pub fn DefaultValidatorPruneLen<T: Config>() -> u64 { T::InitialValidatorPruneLen::get() }
+	#[pallet::type_value] 
 	pub fn DefaultValidatorBatchSize<T: Config>() -> u16 { T::InitialValidatorBatchSize::get() }
 	#[pallet::type_value] 
 	pub fn DefaultValidatorSequenceLen<T: Config>() -> u16 { T::InitialValidatorSequenceLen::get() }
 	#[pallet::type_value] 
 	pub fn DefaultValidatorEpochsPerReset<T: Config>() -> u16 { T::InitialValidatorEpochsPerReset::get() }
 	#[pallet::type_value]
-	pub fn DefaultValidatorExcludeQuantile<T: Config>() -> u16 {T::InitialValidatorExcludeQuantile::get()}
+	pub fn DefaultValidatorExcludeQuantile<T: Config>() -> u16 { T::InitialValidatorExcludeQuantile::get() }
 	#[pallet::type_value] 
 	pub fn DefaultValidatorLogitsDivergence<T: Config>() -> u64 { T::InitialValidatorLogitsDivergence::get() }
-	#[pallet::type_value] 
-	pub fn DefaultValidatorPruneLen<T: Config>() -> u64 { T::InitialValidatorPruneLen::get() }
 	#[pallet::type_value]
-	pub fn DefaultScalingLawPower<T: Config>() -> u16 {T::InitialScalingLawPower::get()}
+	pub fn DefaultScalingLawPower<T: Config>() -> u16 { T::InitialScalingLawPower::get() }
 	#[pallet::type_value]
-	pub fn DefaultSynergyScalingLawPower<T: Config>() -> u16 {T::InitialSynergyScalingLawPower::get()}
+	pub fn DefaultSynergyScalingLawPower<T: Config>() -> u16 { T::InitialSynergyScalingLawPower::get() }
 	#[pallet::type_value] 
 	pub fn DefaultTargetRegistrationsPerInterval<T: Config>() -> u16 { T::InitialTargetRegistrationsPerInterval::get() }
 
@@ -403,6 +403,8 @@ pub mod pallet {
 	pub type ValidatorBatchSize<T> = StorageMap<_, Identity, u16, u16, ValueQuery, DefaultValidatorBatchSize<T> >;
 	#[pallet::storage] /// --- MAP ( netuid ) --> weights_set_rate_limit
 	pub type WeightsSetRateLimit<T> = StorageMap<_, Identity, u16, u64, ValueQuery, DefaultWeightsSetRateLimit<T> >;
+	#[pallet::storage] /// --- MAP ( netuid ) --> validator_prune_len
+	pub type ValidatorPruneLen<T> = StorageMap<_, Identity, u16, u64, ValueQuery, DefaultValidatorPruneLen<T> >;
 	#[pallet::storage] /// --- MAP ( netuid ) --> validator_sequence_length
 	pub type ValidatorSequenceLength<T> = StorageMap<_, Identity, u16, u16, ValueQuery, DefaultValidatorSequenceLen<T> >;
 	#[pallet::storage] /// --- MAP ( netuid ) --> validator_epochs_per_reset
@@ -411,8 +413,6 @@ pub mod pallet {
 	pub type ValidatorExcludeQuantile<T> = StorageMap<_, Identity, u16, u16, ValueQuery, DefaultValidatorExcludeQuantile<T> >;
 	#[pallet::storage] /// --- MAP ( netuid ) --> validator_logits_divergence
 	pub type ValidatorLogitsDivergence<T> = StorageMap<_, Identity, u16, u64, ValueQuery, DefaultValidatorLogitsDivergence<T> >;
-	#[pallet::storage] /// --- MAP ( netuid ) --> validator_prune_len
-	pub type ValidatorPruneLen<T> = StorageMap<_, Identity, u16, u64, ValueQuery, DefaultValidatorPruneLen<T> >;
 	#[pallet::storage] /// --- MAP ( netuid ) --> scaling_law_power
 	pub type ScalingLawPower<T> = StorageMap<_, Identity, u16, u16, ValueQuery, DefaultScalingLawPower<T> >;
 	#[pallet::storage] /// --- MAP ( netuid ) --> synergy_scaling_law_power
@@ -1117,8 +1117,7 @@ pub mod pallet {
 				netuid,
 				coldkey,
 				hotkeys,
-				stakes,
-				balance
+				stakes
 			)
 		}
 

--- a/pallets/paratensor/src/lib.rs
+++ b/pallets/paratensor/src/lib.rs
@@ -103,6 +103,10 @@ pub mod pallet {
 		type InitialValidatorEpochsPerReset: Get<u16>;
 		#[pallet::constant] /// Initial validator exclude quantile.
 		type InitialValidatorExcludeQuantile: Get<u16>;
+		#[pallet::constant] /// Initial validator logits divergence penalty/threshold.
+		type InitialValidatorLogitsDivergence: Get<u64>;
+		#[pallet::constant] /// Initial validator context pruning length.
+		type InitialValidatorPruneLen: Get<u64>; 
 		#[pallet::constant] /// Initial scaling law power.
 		type InitialScalingLawPower: Get<u16>;
 		#[pallet::constant] /// Initial synergy scaling law power.
@@ -123,6 +127,7 @@ pub mod pallet {
 		type InitialWeightsVersionKey: Get<u64>;
 		#[pallet::constant] /// Initial serving rate limit.
 		type InitialServingRateLimit: Get<u64>;
+		
 	}
 
 	pub type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
@@ -352,6 +357,10 @@ pub mod pallet {
 	pub fn DefaultValidatorEpochsPerReset<T: Config>() -> u16 { T::InitialValidatorEpochsPerReset::get() }
 	#[pallet::type_value]
 	pub fn DefaultValidatorExcludeQuantile<T: Config>() -> u16 {T::InitialValidatorExcludeQuantile::get()}
+	#[pallet::type_value] 
+	pub fn DefaultValidatorLogitsDivergence<T: Config>() -> u64 { T::InitialValidatorLogitsDivergence::get() }
+	#[pallet::type_value] 
+	pub fn DefaultValidatorPruneLen<T: Config>() -> u64 { T::InitialValidatorPruneLen::get() }
 	#[pallet::type_value]
 	pub fn DefaultScalingLawPower<T: Config>() -> u16 {T::InitialScalingLawPower::get()}
 	#[pallet::type_value]
@@ -400,6 +409,10 @@ pub mod pallet {
 	pub type ValidatorEpochsPerReset<T> = StorageMap<_, Identity, u16, u16, ValueQuery, DefaultValidatorEpochsPerReset<T> >;
 	#[pallet::storage] /// --- MAP ( netuid ) --> validator_exclude_quantile
 	pub type ValidatorExcludeQuantile<T> = StorageMap<_, Identity, u16, u16, ValueQuery, DefaultValidatorExcludeQuantile<T> >;
+	#[pallet::storage] /// --- MAP ( netuid ) --> validator_logits_divergence
+	pub type ValidatorLogitsDivergence<T> = StorageMap<_, Identity, u16, u64, ValueQuery, DefaultValidatorLogitsDivergence<T> >;
+	#[pallet::storage] /// --- MAP ( netuid ) --> validator_prune_len
+	pub type ValidatorPruneLen<T> = StorageMap<_, Identity, u16, u64, ValueQuery, DefaultValidatorPruneLen<T> >;
 	#[pallet::storage] /// --- MAP ( netuid ) --> scaling_law_power
 	pub type ScalingLawPower<T> = StorageMap<_, Identity, u16, u16, ValueQuery, DefaultScalingLawPower<T> >;
 	#[pallet::storage] /// --- MAP ( netuid ) --> synergy_scaling_law_power
@@ -506,6 +519,8 @@ pub mod pallet {
 		ValidatorSequenceLengthSet( u16, u16 ), // --- Event created when validator sequence length i set for a subnet.
 		ValidatorEpochPerResetSet( u16, u16 ), // --- Event created when validator epoch per reset is set for a subnet.
 		ValidatorExcludeQuantileSet( u16, u16 ), // --- Event created when the validator exclude quantile has been set for a subnet.
+		ValidatorLogitsDivergenceSet( u16, u64 ), /// --- Event created when the validator logits divergence value has been set.
+		ValidatorPruneLenSet( u16, u64 ), /// --- Event created when the validator pruning length has been set.
 		ScalingLawPowerSet( u16, u16 ), // --- Event created when the scaling law power has been set for a subnet.
 		SynergyScalingLawPowerSet( u16, u16 ), // --- Event created when the synergy scaling law has been set for a subnet.
 		WeightsSetRateLimitSet( u16, u64 ), // --- Event create when weights set rate limit has been set for a subnet.
@@ -1239,6 +1254,14 @@ pub mod pallet {
 		#[pallet::weight((0, DispatchClass::Operational, Pays::No))]
 		pub fn sudo_set_validator_exclude_quantile( origin:OriginFor<T>, netuid: u16, validator_exclude_quantile: u16 ) -> DispatchResult {
 			Self::do_sudo_set_validator_exclude_quantile( origin, netuid, validator_exclude_quantile )
+		}
+		#[pallet::weight((0, DispatchClass::Operational, Pays::No))]
+		pub fn sudo_set_validator_prune_len( origin:OriginFor<T>, netuid: u16, validator_prune_len: u64 ) -> DispatchResult {
+			Self::do_sudo_set_validator_prune_len( origin, netuid, validator_prune_len )
+		}
+		#[pallet::weight((0, DispatchClass::Operational, Pays::No))]
+		pub fn sudo_set_validator_logits_divergence( origin:OriginFor<T>, netuid: u16,validator_logits_divergence: u64 ) -> DispatchResult {
+			Self::do_sudo_set_validator_logits_divergence( origin, netuid, validator_logits_divergence )
 		}
 		#[pallet::weight((0, DispatchClass::Operational, Pays::No))]
 		pub fn sudo_set_scaling_law_power( origin:OriginFor<T>, netuid: u16, scaling_law_power: u16 ) -> DispatchResult {

--- a/pallets/paratensor/src/utils.rs
+++ b/pallets/paratensor/src/utils.rs
@@ -129,6 +129,28 @@ impl<T: Config> Pallet<T> {
         Ok(())
     }
 
+    pub fn get_validator_prune_len( netuid: u16 ) -> u64 { ValidatorPruneLen::<T>::get( netuid ) }
+    pub fn set_validator_prune_len( netuid: u16, validator_prune_len: u64 ) { ValidatorPruneLen::<T>::insert( netuid, validator_prune_len ); }
+    pub fn do_sudo_set_validator_prune_len( origin:T::Origin, netuid: u16, validator_prune_len: u64 ) -> DispatchResult {
+        ensure_root( origin )?;
+        ensure!( Self::if_subnet_exist(netuid), Error::<T>::NetworkDoesNotExist );
+        Self::set_validator_prune_len(netuid, validator_prune_len);
+        log::info!("ValidatorPruneLenSet( netuid: {:?} validator_prune_len: {:?} ) ", netuid, validator_prune_len);
+		Self::deposit_event( Event::ValidatorPruneLenSet( netuid, validator_prune_len ));
+		Ok(())
+    }
+
+    pub fn get_validator_logits_divergence( netuid: u16 ) -> u64 { ValidatorLogitsDivergence::<T>::get( netuid ) }
+    pub fn set_validator_logits_divergence( netuid: u16, validator_logits_divergence: u64 ) { ValidatorLogitsDivergence::<T>::insert( netuid, validator_logits_divergence ); }
+    pub fn do_sudo_set_validator_logits_divergence( origin:T::Origin, netuid: u16, validator_logits_divergence: u64 ) -> DispatchResult {
+        ensure_root( origin )?;
+        ensure!( Self::if_subnet_exist(netuid), Error::<T>::NetworkDoesNotExist );
+        Self::set_validator_logits_divergence(netuid, validator_logits_divergence);
+        log::info!("ValidatorLogitsDivergenceSet( netuid: {:?} validator_logits_divergence: {:?} ) ", netuid, validator_logits_divergence);
+        Self::deposit_event( Event::ValidatorLogitsDivergenceSet( netuid, validator_logits_divergence ));
+        Ok(())
+    }
+
     pub fn get_scaling_law_power( netuid: u16 ) -> u16 { ScalingLawPower::<T>::get( netuid ) }
     pub fn set_scaling_law_power( netuid: u16, scaling_law_power: u16 ) { ScalingLawPower::<T>::insert( netuid, scaling_law_power ); }
     pub fn do_sudo_set_scaling_law_power( origin:T::Origin, netuid: u16, scaling_law_power: u16 ) -> DispatchResult {

--- a/pallets/paratensor/tests/mock.rs
+++ b/pallets/paratensor/tests/mock.rs
@@ -118,11 +118,11 @@ parameter_types! {
 
 	pub const InitialValidatorBatchSize: u16 = 10;
 	pub const InitialValidatorSequenceLen: u16 = 10;
+	pub const InitialValidatorPruneLen: u64 = 0;
 	pub const InitialValidatorEpochLen: u16 = 10;
 	pub const InitialValidatorEpochsPerReset: u16 = 10;
 	pub const InitialValidatorExcludeQuantile: u16 = 10;
 	pub const InitialValidatorLogitsDivergence: u64 = 0;
-	pub const InitialValidatorPruneLen: u64 = 0;
 	pub const InitialScalingLawPower: u16 = 50;
 	pub const InitialSynergyScalingLawPower: u16 = 50;
 	pub const InitialMaxAllowedValidators: u16 = 100;
@@ -157,11 +157,11 @@ impl pallet_paratensor::Config for Test {
 	type InitialMaxAllowedUids = InitialMaxAllowedUids;
 	type InitialValidatorBatchSize = InitialValidatorBatchSize;
 	type InitialValidatorSequenceLen = InitialValidatorSequenceLen;
+	type InitialValidatorPruneLen = InitialValidatorPruneLen;
 	type InitialValidatorEpochLen = InitialValidatorEpochLen;
 	type InitialValidatorEpochsPerReset = InitialValidatorEpochsPerReset;
 	type InitialValidatorExcludeQuantile = InitialValidatorExcludeQuantile;
 	type InitialValidatorLogitsDivergence = InitialValidatorLogitsDivergence;
-	type InitialValidatorPruneLen = InitialValidatorPruneLen;
 	type InitialScalingLawPower = InitialScalingLawPower;
 	type InitialSynergyScalingLawPower = InitialSynergyScalingLawPower;
 	type InitialImmunityPeriod = InitialImmunityPeriod;

--- a/pallets/paratensor/tests/mock.rs
+++ b/pallets/paratensor/tests/mock.rs
@@ -121,6 +121,8 @@ parameter_types! {
 	pub const InitialValidatorEpochLen: u16 = 10;
 	pub const InitialValidatorEpochsPerReset: u16 = 10;
 	pub const InitialValidatorExcludeQuantile: u16 = 10;
+	pub const InitialValidatorLogitsDivergence: u64 = 0;
+	pub const InitialValidatorPruneLen: u64 = 0;
 	pub const InitialScalingLawPower: u16 = 50;
 	pub const InitialSynergyScalingLawPower: u16 = 50;
 	pub const InitialMaxAllowedValidators: u16 = 100;
@@ -158,6 +160,8 @@ impl pallet_paratensor::Config for Test {
 	type InitialValidatorEpochLen = InitialValidatorEpochLen;
 	type InitialValidatorEpochsPerReset = InitialValidatorEpochsPerReset;
 	type InitialValidatorExcludeQuantile = InitialValidatorExcludeQuantile;
+	type InitialValidatorLogitsDivergence = InitialValidatorLogitsDivergence;
+	type InitialValidatorPruneLen = InitialValidatorPruneLen;
 	type InitialScalingLawPower = InitialScalingLawPower;
 	type InitialSynergyScalingLawPower = InitialSynergyScalingLawPower;
 	type InitialImmunityPeriod = InitialImmunityPeriod;

--- a/pallets/paratensor/tests/sudo.rs
+++ b/pallets/paratensor/tests/sudo.rs
@@ -37,6 +37,8 @@ fn test_defaults() {
         assert_eq!( ParatensorModule::get_validator_epochs_per_reset( netuid ), 10 );
         assert_eq!( ParatensorModule::get_validator_sequence_length( netuid ), 10 );
         assert_eq!( ParatensorModule::get_validator_exclude_quantile( netuid ), 10 );
+        assert_eq!( ParatensorModule::get_validator_logits_divergence( netuid ), 0 );
+        assert_eq!( ParatensorModule::get_validator_prune_len( netuid ), 0 );
         assert_eq!( ParatensorModule::get_scaling_law_power( netuid ), 50 );
         assert_eq!( ParatensorModule::get_synergy_scaling_law_power( netuid ), 50 );
         assert_eq!( ParatensorModule::get_registrations_this_interval( netuid ), 0 );
@@ -198,6 +200,38 @@ fn test_sudo_set_validator_exclude_quantile() {
         assert_eq!( ParatensorModule::get_validator_exclude_quantile(netuid), init_value);
         assert_ok!( ParatensorModule::sudo_set_validator_exclude_quantile(<<Test as Config>::Origin>::root(), netuid, to_be_set) );
         assert_eq!( ParatensorModule::get_validator_exclude_quantile(netuid), to_be_set);
+    });
+}
+
+#[test]
+fn test_sudo_validator_prune_len() {
+	new_test_ext().execute_with(|| {
+        let netuid: u16 = 1;
+        let to_be_set: u64 = 10;
+        let init_value: u64 = ParatensorModule::get_validator_prune_len( netuid );
+        add_network(netuid, 10, 0);
+        
+        assert_eq!( ParatensorModule::sudo_set_validator_prune_len(<<Test as Config>::Origin>::signed(0), netuid, to_be_set),  Err(DispatchError::BadOrigin.into()) );
+        assert_eq!( ParatensorModule::sudo_set_validator_prune_len(<<Test as Config>::Origin>::root(), netuid + 1, to_be_set), Err(Error::<Test>::NetworkDoesNotExist.into()) );
+        assert_eq!( ParatensorModule::get_validator_prune_len(netuid), init_value);
+        assert_ok!( ParatensorModule::sudo_set_validator_prune_len(<<Test as Config>::Origin>::root(), netuid, to_be_set) );
+        assert_eq!( ParatensorModule::get_validator_prune_len(netuid), to_be_set);
+    });
+}
+
+#[test]
+fn test_sudo_validator_logits_divergence() {
+	new_test_ext().execute_with(|| {
+        let netuid: u16 = 1;
+        let to_be_set: u64 = 10;
+        let init_value: u64 = ParatensorModule::get_validator_logits_divergence( netuid );
+        add_network(netuid, 10, 0);
+
+        assert_eq!( ParatensorModule::sudo_set_validator_logits_divergence(<<Test as Config>::Origin>::signed(0), netuid, to_be_set),  Err(DispatchError::BadOrigin.into()) );
+        assert_eq!( ParatensorModule::sudo_set_validator_logits_divergence(<<Test as Config>::Origin>::root(), netuid + 1, to_be_set), Err(Error::<Test>::NetworkDoesNotExist.into()) );
+        assert_eq!( ParatensorModule::get_validator_logits_divergence(netuid), init_value);
+        assert_ok!( ParatensorModule::sudo_set_validator_logits_divergence(<<Test as Config>::Origin>::root(), netuid, to_be_set) );
+        assert_eq!( ParatensorModule::get_validator_logits_divergence(netuid), to_be_set);
     });
 }
 


### PR DESCRIPTION
This PR implements https://github.com/opentensor/subtensor/pull/43  
This adds the two new validator hyperparams:
- `ValidatorPruneLen: u64`
- `ValidatorLogitsDivergence: u64`